### PR TITLE
Turn off rule to remove ip tables (OPS-6042)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -167,7 +167,7 @@ rhel7cis_rule_3_3_9: true
 rhel7cis_rule_3_4_1: true
 rhel7cis_rule_3_4_2: true
 rhel7cis_rule_3_5_1_1: true
-rhel7cis_rule_3_5_1_2: true
+rhel7cis_rule_3_5_1_2: false # Docker needs IP Tables https://docs.docker.com/network/iptables/
 rhel7cis_rule_3_5_1_3: true
 rhel7cis_rule_3_5_1_4: true
 rhel7cis_rule_3_5_1_5: true
@@ -175,7 +175,7 @@ rhel7cis_rule_3_5_1_6: true
 rhel7cis_rule_3_5_1_7: true
 rhel7cis_rule_3_5_2_1: true
 rhel7cis_rule_3_5_2_2: true
-rhel7cis_rule_3_5_2_3: true
+rhel7cis_rule_3_5_2_3: false # Docker needs IP Tables https://docs.docker.com/network/iptables/
 rhel7cis_rule_3_5_2_4: true
 rhel7cis_rule_3_5_2_5: true
 rhel7cis_rule_3_5_2_6: true


### PR DESCRIPTION
Docker needs ip tables to function correctly, turning off rules which remove it