### PR TITLE
OPS-6042: Disable rule that makes log dir unreadable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -233,7 +233,7 @@ rhel7cis_rule_4_2_1_6: true
 rhel7cis_rule_4_2_2_1: true
 rhel7cis_rule_4_2_2_2: true
 rhel7cis_rule_4_2_2_3: true
-rhel7cis_rule_4_2_3: true
+rhel7cis_rule_4_2_3: false
 rhel7cis_rule_4_2_4: true
 
 # Section 5 rules


### PR DESCRIPTION
Why is it soo hard to do a PR with this repo.

The rule removes read access from everyone but root. This breaks at least td-agent which tries to create it's log dir on start up but can't even find it and gets and error trying to create it because it thinks it's not there.