### PR TITLE
OPS-7013: Fix 1.6.2 task

### DIFF
--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -39,7 +39,7 @@
   - rule_1.6.1
 
 - name: "NOTAUTOMATED | 1.6.2 | PATCH | Ensure XD/NX support is enabled"
-  shell: dmesg|grep -E "NX|XD" | grep " active"
+  shell: journalctl -k |grep -E "NX|XD" | grep " active"
   changed_when: no
   when:
   - rhel7cis_rule_1_6_2


### PR DESCRIPTION
dmesg has a buffer and the kernel messages disappear over time.  Use Journalctl so work around that.