### PR TITLE
OPS-7013: Fix SGID executable check on docker hosts

### DIFF
--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -263,6 +263,7 @@
     failed_when: false
     changed_when: false
     register: rhel_07_6_1_14_perms_results
+    when: item.mount is not match("/var/lib/docker/.*")
     with_items: "{{ ansible_mounts }}"
 
   - name: "NOTSCORED | 6.1.14 | AUDIT | Audit SGID executables |  Alert no SGID executables exist"


### PR DESCRIPTION
Do not scan for SGID executables on docker mounts.  This was mainly an issue in ECS where containers are coming and going, the check would fail if a mount disappeared when the container was removed.