### PR TITLE
OPS-7013: Fix find race condition in 4.1.11

### DIFF
--- a/tasks/section_4/cis_4.1.2.x.yml
+++ b/tasks/section_4/cis_4.1.2.x.yml
@@ -231,7 +231,7 @@
 - name: "AUTOMATED | 4.1.11 | PATCH | Ensure use of privileged commands is collected"
   block:
       - name: "AUTOMATED | 4.1.11 | AUDIT | Ensure use of privileged commands is collected"
-        shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -xdev -type f -perm -4000 -o -type f -perm -2000; done
+        shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -ignore_readdir_race -xdev -type f -perm -4000 -o -type f -perm -2000; done
         register: priv_procs
         changed_when: no
         check_mode: no


### PR DESCRIPTION
We've been getting intermittent errors such as this:
```find: '/tmp/runc-process217760033': No such file or directory```

which happens when a container goes away during this ansible run.  Adding the find option to ignore errors due to readdir race conditions.