### PR TITLE
OPS-7270: Fix for session duration and adding hs customizations

### DIFF
--- a/README-HS.md
+++ b/README-HS.md
@@ -1,0 +1,6 @@
+# Headspace RHEL7-CIS fork
+## Customizations
+Headspace customizations can be found in the following files/directories
+* `defaults/main.yml`
+* `tasks/main.yml`
+* `tasks/hs_customizations/*`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -593,3 +593,22 @@ audit_results: |
       The pre remediation results are: {{ pre_audit_summary }}.
       The post remediation results are: {{ post_audit_summary }}.
       Full breakdown can be found in {{ goss_out_dir }}
+
+######### Headspace Customizations #############
+rhel7cis_hscustom: true
+
+## HS Compliment Rules and vars
+# These are used to compliment current upstream rules so we can be more compliant
+# by default all these rules are set to true
+hs_rhel7cis_shell_session_timeout:
+  file: /etc/bashrc
+  timeout: 600
+hs_rhel7cis_rule_5_4_4: true
+
+
+## HS Override Rules
+# These are used to fix upstream rules that might have bugs or break things
+# if you want to use these override rules
+# be sure to disable the non `hs_` versions of them
+# by default these are all false.
+hs_rhel7cis_rule_4_1_11: false

--- a/tasks/hs_customizations/cis_4.1.2.x.yml
+++ b/tasks/hs_customizations/cis_4.1.2.x.yml
@@ -1,0 +1,25 @@
+- name: "AUTOMATED | 4.1.11 | PATCH | Ensure use of privileged commands is collected"
+  block:
+  - name: "AUTOMATED | 4.1.11 | AUDIT | Ensure use of privileged commands is collected"
+    shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -ignore_readdir_race -xdev -type f -perm -4000 -o -type f -perm -2000; done
+    register: priv_procs
+    changed_when: no
+    check_mode: no
+
+  - name: "AUTOMATED | 4.1.11 | PATCH | Ensure use of privileged commands is collected"
+    template:
+      src: audit/priv_commands.rules.j2
+      dest: /etc/audit/rules.d/priv_commands.rules
+      owner: root
+      group: root
+      mode: 0600
+    notify: restart auditd
+  when:
+  - hs_rhel7cis_rule_4_1_11
+  - !rhel7cis_rule_4_1_11
+  tags:
+  - level2
+  - auditd
+  - patch
+  - automated
+  - rule_4.1.11

--- a/tasks/hs_customizations/cis_4.1.2.x.yml
+++ b/tasks/hs_customizations/cis_4.1.2.x.yml
@@ -16,7 +16,7 @@
     notify: restart auditd
   when:
   - hs_rhel7cis_rule_4_1_11
-  - !rhel7cis_rule_4_1_11
+  - not rhel7cis_rule_4_1_11
   tags:
   - level2
   - auditd

--- a/tasks/hs_customizations/cis_5.4.x.yml
+++ b/tasks/hs_customizations/cis_5.4.x.yml
@@ -1,0 +1,21 @@
+- name: "SCORED | 5.4.4 | PATCH | HS - Ensure default user shell timeout is configured"
+  blockinfile:
+    create: yes
+    mode: 0644
+    dest: "{{ item.dest }}"
+    state: "{{ item.state }}"
+    marker: "# {mark} ANSIBLE MANAGED"
+    block: |
+      # Set session timeout - CIS ID RHEL-07-5.4.4
+      TMOUT={{ rhel7cis_shell_session_timeout.timeout }}
+      readonly TMOUT
+      export TMOUT
+  loop:
+  - dest: "{{ rhel7cis_hs_shell_session_timeout.file }}"
+    state: present
+  when:
+  - hs_rhel7cis_rule_5_4_4
+  tags:
+  - level2
+  - patch
+  - rule_5.4.4

--- a/tasks/hs_customizations/main.yml
+++ b/tasks/hs_customizations/main.yml
@@ -1,0 +1,3 @@
+---
+- include: cis_5.4.x.yml
+- include: cis_4.1.2.x.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,6 +108,11 @@
   tags:
   - rhel7cis_section6
 
+- include: hs_customizations/main.yml
+  when: rhel7cis_hscustom
+  tags:
+  - rhel7cis_hscustom
+
 - include: post.yml
   tags:
   - post_tasks

--- a/tasks/section_4/cis_4.1.2.x.yml
+++ b/tasks/section_4/cis_4.1.2.x.yml
@@ -233,7 +233,7 @@
 - name: "AUTOMATED | 4.1.11 | PATCH | Ensure use of privileged commands is collected"
   block:
   - name: "AUTOMATED | 4.1.11 | AUDIT | Ensure use of privileged commands is collected"
-    shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -ignore_readdir_race -xdev -type f -perm -4000 -o -type f -perm -2000; done
+    shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null; done
     register: priv_procs
     changed_when: no
     check_mode: no


### PR DESCRIPTION
AWS Inspector checks for /etc/bashrc as well as /etc/profile*.  Fix for remediation.

Also adding hs_customization tasks so hopefully merging upstream changes will be easier than if we edit their tasks directly.